### PR TITLE
feat: add external player support (VLC/MPV)

### DIFF
--- a/src/components/about-category/about-category.html
+++ b/src/components/about-category/about-category.html
@@ -57,7 +57,25 @@
     </div>
 </div>
 
-<p style="color:rgb(204, 204, 204);">Note: When enabled, streams will always open in the selected external player instead of the built-in player. The player must be installed on your system.</p>
+<div class="option-vFOAS" id="vlc-path-option" style="display: {{ vlc_path_display }};">
+    <div class="heading-dYMDt">
+        <div class="label-qI6Vh">VLC Path (optional)</div>
+    </div>
+    <div class="content-P2T0i">
+        <input type="text" id="external-player-vlc-path" class="search-input-bAgAh text-input-hnLiz" placeholder="Auto-detect (leave empty)" value="{{ vlc_custom_path }}" style="width: 100%; padding: 0 15px; background-color: rgba(255, 255, 255, 0.08); color: white; border: 1px solid transparent; border-radius: 20px; outline: none; box-sizing: border-box; height: 42px;" />
+    </div>
+</div>
+
+<div class="option-vFOAS" id="mpv-path-option" style="display: {{ mpv_path_display }};">
+    <div class="heading-dYMDt">
+        <div class="label-qI6Vh">MPV Path (optional)</div>
+    </div>
+    <div class="content-P2T0i">
+        <input type="text" id="external-player-mpv-path" class="search-input-bAgAh text-input-hnLiz" placeholder="Auto-detect (leave empty)" value="{{ mpv_custom_path }}" style="width: 100%; padding: 0 15px; background-color: rgba(255, 255, 255, 0.08); color: white; border: 1px solid transparent; border-radius: 20px; outline: none; box-sizing: border-box; height: 42px;" />
+    </div>
+</div>
+
+<p style="color:rgb(204, 204, 204);">Note: When enabled, streams will always open in the selected external player instead of the built-in player. The player must be installed on your system. You can optionally set a custom path to the player executable.</p>
 <br/>
 
 <div class="option-vFOAS">

--- a/src/components/about-category/about-category.html
+++ b/src/components/about-category/about-category.html
@@ -44,6 +44,25 @@
 <div class="option-vFOAS">
     <div class="heading-dYMDt">
         <div class="label-qI6Vh">
+            External Player
+        </div>
+    </div>
+
+    <div class="content-P2T0i">
+        <select data-key="externalPlayer" id="external-player-dropdown" class="search-input-bAgAh text-input-hnLiz plugin-setting-select" style="width: 100%; padding: 0 15px; cursor: pointer; background-color: rgba(255, 255, 255, 0.08); color: white; border: 1px solid transparent; border-radius: 20px; outline: none; appearance: auto; box-sizing: border-box; height: 42px;">
+            <option value="disabled" {{ selected_disabled }} style="background-color: #1a1a1a; color: white;">Disabled (Default)</option>
+            <option value="vlc" {{ selected_vlc }} style="background-color: #1a1a1a; color: white;">VLC</option>
+            <option value="mpv" {{ selected_mpv }} style="background-color: #1a1a1a; color: white;">MPV</option>
+        </select>
+    </div>
+</div>
+
+<p style="color:rgb(204, 204, 204);">Note: When enabled, streams will always open in the selected external player instead of the built-in player. The player must be installed on your system.</p>
+<br/>
+
+<div class="option-vFOAS">
+    <div class="heading-dYMDt">
+        <div class="label-qI6Vh">
             ANGLE graphics backend
         </div>
     </div>

--- a/src/components/about-category/aboutCategory.ts
+++ b/src/components/about-category/aboutCategory.ts
@@ -1,6 +1,6 @@
 import TemplateCache from '../../utils/templateCache';
 import { VALID_RENDERERS } from '../../interfaces/RendererTypes';
-import { VALID_EXTERNAL_PLAYERS } from '../../interfaces/ExternalPlayerTypes';
+import { VALID_EXTERNAL_PLAYERS, type ExternalPlayer } from '../../interfaces/ExternalPlayerTypes';
 
 export function getAboutCategoryTemplate(
     version: string,
@@ -8,7 +8,7 @@ export function getAboutCategoryTemplate(
     discordRichPresence: boolean,
     enableTransparentThemes: boolean,
     currentAngle: string,
-    currentExternalPlayer: string = 'disabled'
+    currentExternalPlayer: ExternalPlayer = 'disabled'
 ): string {
     let template = TemplateCache.load(__dirname, 'about-category');
 

--- a/src/components/about-category/aboutCategory.ts
+++ b/src/components/about-category/aboutCategory.ts
@@ -1,12 +1,14 @@
 import TemplateCache from '../../utils/templateCache';
 import { VALID_RENDERERS } from '../../interfaces/RendererTypes';
+import { VALID_EXTERNAL_PLAYERS } from '../../interfaces/ExternalPlayerTypes';
 
 export function getAboutCategoryTemplate(
-    version: string, 
-    checkForUpdatesOnStartup: boolean, 
-    discordRichPresence: boolean, 
+    version: string,
+    checkForUpdatesOnStartup: boolean,
+    discordRichPresence: boolean,
     enableTransparentThemes: boolean,
-    currentAngle: string
+    currentAngle: string,
+    currentExternalPlayer: string = 'disabled'
 ): string {
     let template = TemplateCache.load(__dirname, 'about-category');
 
@@ -18,10 +20,16 @@ export function getAboutCategoryTemplate(
         .replace("{{ disabled }}", process.platform == "darwin" ? "disabled" : "")
         .replace("{{ disabled_d3d11 }}", process.platform != "win32" ? "disabled" : "")
         .replace("{{ disabled_d3d9 }}", process.platform != "win32" ? "disabled" : "")
-    
+
     VALID_RENDERERS.forEach(renderer => {
         const placeholder = `{{ selected_${renderer} }}`;
         const replacement = (currentAngle === renderer) ? "selected" : "";
+        template = template.replace(placeholder, replacement);
+    });
+
+    VALID_EXTERNAL_PLAYERS.forEach(player => {
+        const placeholder = `{{ selected_${player} }}`;
+        const replacement = (currentExternalPlayer === player) ? "selected" : "";
         template = template.replace(placeholder, replacement);
     });
 

--- a/src/components/about-category/aboutCategory.ts
+++ b/src/components/about-category/aboutCategory.ts
@@ -8,7 +8,9 @@ export function getAboutCategoryTemplate(
     discordRichPresence: boolean,
     enableTransparentThemes: boolean,
     currentAngle: string,
-    currentExternalPlayer: ExternalPlayer = 'disabled'
+    currentExternalPlayer: ExternalPlayer = 'disabled',
+    vlcCustomPath: string = '',
+    mpvCustomPath: string = ''
 ): string {
     let template = TemplateCache.load(__dirname, 'about-category');
 
@@ -32,6 +34,12 @@ export function getAboutCategoryTemplate(
         const replacement = (currentExternalPlayer === player) ? "selected" : "";
         template = template.replace(placeholder, replacement);
     });
+
+    template = template
+        .replace('{{ vlc_path_display }}', currentExternalPlayer === 'vlc' ? '' : 'none')
+        .replace('{{ mpv_path_display }}', currentExternalPlayer === 'mpv' ? '' : 'none')
+        .replace('{{ vlc_custom_path }}', vlcCustomPath)
+        .replace('{{ mpv_custom_path }}', mpvCustomPath);
 
     return template;
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -51,6 +51,7 @@ export const STORAGE_KEYS = {
     CURRENT_THEME: 'currentTheme',
     DISCORD_RPC: 'discordrichpresence',
     CHECK_UPDATES_ON_STARTUP: 'checkForUpdatesOnStartup',
+    EXTERNAL_PLAYER: 'externalPlayer',
 } as const;
 
 // IPC Channel names for main <-> renderer communication
@@ -65,7 +66,9 @@ export const IPC_CHANNELS = {
     FULLSCREEN_CHANGED: 'fullscreen-changed',
     GET_GPU_RENDERER: 'get-gpu-renderer',
     SET_GPU_RENDERER: 'set-gpu-renderer',
-    SHOW_ALERT: 'show-alert'
+    SHOW_ALERT: 'show-alert',
+    LAUNCH_EXTERNAL_PLAYER: 'launch-external-player',
+    GET_EXTERNAL_PLAYER_PATHS: 'get-external-player-paths',
 } as const;
 
 // File extensions for mods

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -52,6 +52,14 @@ export const STORAGE_KEYS = {
     DISCORD_RPC: 'discordrichpresence',
     CHECK_UPDATES_ON_STARTUP: 'checkForUpdatesOnStartup',
     EXTERNAL_PLAYER: 'externalPlayer',
+    EXTERNAL_PLAYER_VLC_PATH: 'externalPlayerVlcPath',
+    EXTERNAL_PLAYER_MPV_PATH: 'externalPlayerMpvPath',
+} as const;
+
+/** Maps a player name to its custom-path storage key. */
+export const PLAYER_PATH_STORAGE_KEY: Record<string, string> = {
+    vlc: STORAGE_KEYS.EXTERNAL_PLAYER_VLC_PATH,
+    mpv: STORAGE_KEYS.EXTERNAL_PLAYER_MPV_PATH,
 } as const;
 
 // IPC Channel names for main <-> renderer communication

--- a/src/controllers/externalPlayerController.ts
+++ b/src/controllers/externalPlayerController.ts
@@ -1,0 +1,64 @@
+import { ipcMain } from 'electron';
+import { execFile } from 'child_process';
+import { existsSync } from 'fs';
+import { getLogger } from '../utils/logger';
+import { IPC_CHANNELS } from '../constants';
+
+const logger = getLogger("ExternalPlayerController");
+
+// Common install paths per platform
+const PLAYER_PATHS: Record<string, Record<string, string[]>> = {
+    win32: {
+        vlc: [
+            'C:\\Program Files\\VideoLAN\\VLC\\vlc.exe',
+            'C:\\Program Files (x86)\\VideoLAN\\VLC\\vlc.exe',
+        ],
+        mpv: [
+            'C:\\Program Files\\mpv\\mpv.exe',
+            'C:\\Program Files (x86)\\mpv\\mpv.exe',
+        ],
+    },
+    darwin: {
+        vlc: ['/Applications/VLC.app/Contents/MacOS/VLC'],
+        mpv: ['/usr/local/bin/mpv', '/opt/homebrew/bin/mpv'],
+    },
+    linux: {
+        vlc: ['/usr/bin/vlc'],
+        mpv: ['/usr/bin/mpv'],
+    },
+};
+
+function findPlayerPath(player: 'vlc' | 'mpv'): string | null {
+    const platform = process.platform;
+    const paths = PLAYER_PATHS[platform]?.[player] ?? [];
+    for (const p of paths) {
+        if (existsSync(p)) return p;
+    }
+    return null;
+}
+
+export const externalPlayerController = {
+    initIPC: () => {
+        ipcMain.handle(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, (_, player: string, streamUrl: string) => {
+            const playerPath = findPlayerPath(player as 'vlc' | 'mpv');
+            if (!playerPath) {
+                logger.error(`${player} not found at any known path.`);
+                return { success: false, error: `${player} not found. Please install it or check the installation path.` };
+            }
+
+            logger.info(`Launching ${player} at ${playerPath} with URL: ${streamUrl}`);
+            const child = execFile(playerPath, [streamUrl], (err) => {
+                if (err) logger.error(`Failed to launch ${player}: ${err.message}`);
+            });
+            child.unref();
+            return { success: true };
+        });
+
+        ipcMain.handle(IPC_CHANNELS.GET_EXTERNAL_PLAYER_PATHS, () => {
+            return {
+                vlc: findPlayerPath('vlc'),
+                mpv: findPlayerPath('mpv'),
+            };
+        });
+    }
+};

--- a/src/controllers/externalPlayerController.ts
+++ b/src/controllers/externalPlayerController.ts
@@ -40,16 +40,16 @@ function findPlayerPath(player: 'vlc' | 'mpv'): string | null {
 
 export const externalPlayerController = {
     initIPC: () => {
-        ipcMain.handle(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, (_, player: string, streamUrl: string) => {
+        ipcMain.handle(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, (_, player: string, streamUrl: string, customPath?: string) => {
             if (!VALID_EXTERNAL_PLAYERS.includes(player as ExternalPlayer) || player === 'disabled') {
                 logger.error(`Invalid external player: ${player}`);
                 return { success: false, error: `Invalid player: ${player}` };
             }
 
-            const playerPath = findPlayerPath(player as 'vlc' | 'mpv');
+            const playerPath = customPath || findPlayerPath(player as 'vlc' | 'mpv');
             if (!playerPath) {
                 logger.error(`${player} not found at any known path.`);
-                return { success: false, error: `${player} not found. Please install it or check the installation path.` };
+                return { success: false, error: `${player} not found. Please install it or set a custom path in settings.` };
             }
 
             logger.info(`Launching ${player} at ${playerPath} with URL: ${streamUrl}`);

--- a/src/controllers/externalPlayerController.ts
+++ b/src/controllers/externalPlayerController.ts
@@ -3,6 +3,7 @@ import { execFile } from 'child_process';
 import { existsSync } from 'fs';
 import { getLogger } from '../utils/logger';
 import { IPC_CHANNELS } from '../constants';
+import { VALID_EXTERNAL_PLAYERS, type ExternalPlayer } from '../interfaces/ExternalPlayerTypes';
 
 const logger = getLogger("ExternalPlayerController");
 
@@ -40,6 +41,11 @@ function findPlayerPath(player: 'vlc' | 'mpv'): string | null {
 export const externalPlayerController = {
     initIPC: () => {
         ipcMain.handle(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, (_, player: string, streamUrl: string) => {
+            if (!VALID_EXTERNAL_PLAYERS.includes(player as ExternalPlayer) || player === 'disabled') {
+                logger.error(`Invalid external player: ${player}`);
+                return { success: false, error: `Invalid player: ${player}` };
+            }
+
             const playerPath = findPlayerPath(player as 'vlc' | 'mpv');
             if (!playerPath) {
                 logger.error(`${player} not found at any known path.`);

--- a/src/interfaces/ExternalPlayerTypes.ts
+++ b/src/interfaces/ExternalPlayerTypes.ts
@@ -1,0 +1,2 @@
+export const VALID_EXTERNAL_PLAYERS = ["disabled", "vlc", "mpv"] as const;
+export type ExternalPlayer = typeof VALID_EXTERNAL_PLAYERS[number];

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { setupWindowControls } from "./controllers/windowController";
 import { setupUpdater } from "./controllers/updaterController";
 import { setupWindowTransparency } from "./controllers/transparencyController";
 import { gpuController } from "./controllers/gpuController";
+import { externalPlayerController } from "./controllers/externalPlayerController";
 
 app.setName("stremio-enhanced");
 const userDataPath = app.getPath('userData');
@@ -200,7 +201,8 @@ app.on("ready", async () => {
     setupUpdater();
     setupWindowTransparency(transparencyFlagPath);
     gpuController.initIPC(userDataPath);
-    
+    externalPlayerController.initIPC();
+
     // macOS: protocol URLs are sent via 'open-url'
     app.on('open-url', (event, url) => {
         event.preventDefault();

--- a/src/preload/api/externalPlayer.ts
+++ b/src/preload/api/externalPlayer.ts
@@ -1,0 +1,11 @@
+import { ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '../../constants';
+
+export const externalPlayerAPI = {
+    launchExternalPlayer: (player: string, streamUrl: string): Promise<{ success: boolean; error?: string }> => {
+        return ipcRenderer.invoke(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, player, streamUrl);
+    },
+    getExternalPlayerPaths: (): Promise<{ vlc: string | null; mpv: string | null }> => {
+        return ipcRenderer.invoke(IPC_CHANNELS.GET_EXTERNAL_PLAYER_PATHS);
+    },
+};

--- a/src/preload/api/externalPlayer.ts
+++ b/src/preload/api/externalPlayer.ts
@@ -3,8 +3,8 @@ import { IPC_CHANNELS } from '../../constants';
 import { type ExternalPlayer } from '../../interfaces/ExternalPlayerTypes';
 
 export const externalPlayerAPI = {
-    launchExternalPlayer: (player: ExternalPlayer, streamUrl: string): Promise<{ success: boolean; error?: string }> => {
-        return ipcRenderer.invoke(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, player, streamUrl);
+    launchExternalPlayer: (player: ExternalPlayer, streamUrl: string, customPath?: string): Promise<{ success: boolean; error?: string }> => {
+        return ipcRenderer.invoke(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, player, streamUrl, customPath);
     },
     getExternalPlayerPaths: (): Promise<{ vlc: string | null; mpv: string | null }> => {
         return ipcRenderer.invoke(IPC_CHANNELS.GET_EXTERNAL_PLAYER_PATHS);

--- a/src/preload/api/externalPlayer.ts
+++ b/src/preload/api/externalPlayer.ts
@@ -1,8 +1,9 @@
 import { ipcRenderer } from 'electron';
 import { IPC_CHANNELS } from '../../constants';
+import { type ExternalPlayer } from '../../interfaces/ExternalPlayerTypes';
 
 export const externalPlayerAPI = {
-    launchExternalPlayer: (player: string, streamUrl: string): Promise<{ success: boolean; error?: string }> => {
+    launchExternalPlayer: (player: ExternalPlayer, streamUrl: string): Promise<{ success: boolean; error?: string }> => {
         return ipcRenderer.invoke(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, player, streamUrl);
     },
     getExternalPlayerPaths: (): Promise<{ vlc: string | null; mpv: string | null }> => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,6 +13,7 @@ import { settingsAPI } from './api/settings';
 import { initializeUserSettings, reloadServer, applyUserTheme, loadEnabledPlugins } from "./setup/initialization";
 import { addTitleBar, getTransparencyStatus } from "./ui/titleBar";
 import { checkSettings } from "./ui/settings/settingsInjector";
+import { checkExternalPlayer } from "./ui/externalPlayerInterceptor";
 import { applyThemeAPI } from "./api/applyTheme";
 import { gpuRendererAPI } from "./api/gpuRenderer";
 import { externalPlayerAPI } from "./api/externalPlayer";
@@ -43,6 +44,7 @@ window.addEventListener("load", () => {
     window.addEventListener("hashchange", () => {
         if (isTransparencyEnabled) addTitleBar();
         checkSettings();
+        checkExternalPlayer();
         EmbeddedSubtitles.checkWatching();
     });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,7 @@ import { addTitleBar, getTransparencyStatus } from "./ui/titleBar";
 import { checkSettings } from "./ui/settings/settingsInjector";
 import { applyThemeAPI } from "./api/applyTheme";
 import { gpuRendererAPI } from "./api/gpuRenderer";
+import { externalPlayerAPI } from "./api/externalPlayer";
 import { pluginLogger } from "./api/pluginLogger";
 
 export const stremioEnhancedAPI = {
@@ -23,6 +24,7 @@ export const stremioEnhancedAPI = {
     ...pluginLogger,
     ...applyThemeAPI,
     ...gpuRendererAPI,
+    ...externalPlayerAPI,
 };
 
 contextBridge.exposeInMainWorld('StremioEnhancedAPI', stremioEnhancedAPI);

--- a/src/preload/ui/externalPlayerInterceptor.ts
+++ b/src/preload/ui/externalPlayerInterceptor.ts
@@ -1,0 +1,39 @@
+import { STORAGE_KEYS } from '../../constants';
+import { externalPlayerAPI } from '../api/externalPlayer';
+import PlaybackState from '../../utils/PlaybackState';
+import Helpers from '../../utils/Helpers';
+import { getLogger } from '../../utils/logger';
+
+const logger = getLogger("ExternalPlayerInterceptor");
+
+export function checkExternalPlayer(): void {
+    const externalPlayer = localStorage.getItem(STORAGE_KEYS.EXTERNAL_PLAYER);
+    if (!externalPlayer || externalPlayer === 'disabled') return;
+    if (!location.href.includes('#/player')) return;
+
+    launchExternal(externalPlayer);
+}
+
+async function launchExternal(player: string): Promise<void> {
+    logger.info(`External player interceptor triggered for ${player}`);
+
+    const playerState = await PlaybackState.getPlayerState();
+    if (!playerState?.stream?.content?.url) {
+        logger.error("Could not retrieve stream URL for external player.");
+        Helpers.createToast("extPlayerError", "External Player", "Could not get stream URL.", "fail");
+        return;
+    }
+
+    const streamUrl = playerState.stream.content.url;
+    logger.info(`Launching ${player} with stream URL: ${streamUrl}`);
+
+    // Navigate back before launching to prevent the built-in player from loading
+    history.back();
+
+    const result = await externalPlayerAPI.launchExternalPlayer(player, streamUrl);
+    if (result.success) {
+        Helpers.createToast("extPlayerLaunch", "External Player", `Opening stream in ${player.toUpperCase()}...`, "success");
+    } else {
+        Helpers.createToast("extPlayerError", "External Player", result.error ?? "Failed to launch player.", "fail");
+    }
+}

--- a/src/preload/ui/externalPlayerInterceptor.ts
+++ b/src/preload/ui/externalPlayerInterceptor.ts
@@ -1,39 +1,48 @@
 import { STORAGE_KEYS } from '../../constants';
 import { externalPlayerAPI } from '../api/externalPlayer';
+import { type ExternalPlayer } from '../../interfaces/ExternalPlayerTypes';
 import PlaybackState from '../../utils/PlaybackState';
 import Helpers from '../../utils/Helpers';
 import { getLogger } from '../../utils/logger';
 
 const logger = getLogger("ExternalPlayerInterceptor");
 
+let isLaunching = false;
+
 export function checkExternalPlayer(): void {
+    if (isLaunching) return;
     const externalPlayer = localStorage.getItem(STORAGE_KEYS.EXTERNAL_PLAYER);
     if (!externalPlayer || externalPlayer === 'disabled') return;
     if (!location.href.includes('#/player')) return;
 
-    launchExternal(externalPlayer);
+    launchExternal(externalPlayer as ExternalPlayer);
 }
 
-async function launchExternal(player: string): Promise<void> {
-    logger.info(`External player interceptor triggered for ${player}`);
+async function launchExternal(player: ExternalPlayer): Promise<void> {
+    isLaunching = true;
+    try {
+        logger.info(`External player interceptor triggered for ${player}`);
 
-    const playerState = await PlaybackState.getPlayerState();
-    if (!playerState?.stream?.content?.url) {
-        logger.error("Could not retrieve stream URL for external player.");
-        Helpers.createToast("extPlayerError", "External Player", "Could not get stream URL.", "fail");
-        return;
-    }
+        const playerState = await PlaybackState.getPlayerState();
+        if (!playerState?.stream?.content?.url) {
+            logger.error("Could not retrieve stream URL for external player.");
+            Helpers.createToast("extPlayerError", "External Player", "Could not get stream URL.", "fail");
+            return;
+        }
 
-    const streamUrl = playerState.stream.content.url;
-    logger.info(`Launching ${player} with stream URL: ${streamUrl}`);
+        const streamUrl = playerState.stream.content.url;
+        logger.info(`Launching ${player} with stream URL: ${streamUrl}`);
 
-    // Navigate back before launching to prevent the built-in player from loading
-    history.back();
+        // Navigate back before launching to prevent the built-in player from loading
+        history.back();
 
-    const result = await externalPlayerAPI.launchExternalPlayer(player, streamUrl);
-    if (result.success) {
-        Helpers.createToast("extPlayerLaunch", "External Player", `Opening stream in ${player.toUpperCase()}...`, "success");
-    } else {
-        Helpers.createToast("extPlayerError", "External Player", result.error ?? "Failed to launch player.", "fail");
+        const result = await externalPlayerAPI.launchExternalPlayer(player, streamUrl);
+        if (result.success) {
+            Helpers.createToast("extPlayerLaunch", "External Player", `Opening stream in ${player.toUpperCase()}...`, "success");
+        } else {
+            Helpers.createToast("extPlayerError", "External Player", result.error ?? "Failed to launch player.", "fail");
+        }
+    } finally {
+        isLaunching = false;
     }
 }

--- a/src/preload/ui/externalPlayerInterceptor.ts
+++ b/src/preload/ui/externalPlayerInterceptor.ts
@@ -1,4 +1,4 @@
-import { STORAGE_KEYS } from '../../constants';
+import { STORAGE_KEYS, PLAYER_PATH_STORAGE_KEY } from '../../constants';
 import { externalPlayerAPI } from '../api/externalPlayer';
 import { type ExternalPlayer } from '../../interfaces/ExternalPlayerTypes';
 import PlaybackState from '../../utils/PlaybackState';
@@ -36,7 +36,9 @@ async function launchExternal(player: ExternalPlayer): Promise<void> {
         // Navigate back before launching to prevent the built-in player from loading
         history.back();
 
-        const result = await externalPlayerAPI.launchExternalPlayer(player, streamUrl);
+        const customPath = localStorage.getItem(PLAYER_PATH_STORAGE_KEY[player]);
+
+        const result = await externalPlayerAPI.launchExternalPlayer(player, streamUrl, customPath || undefined);
         if (result.success) {
             Helpers.createToast("extPlayerLaunch", "External Player", `Opening stream in ${player.toUpperCase()}...`, "success");
         } else {

--- a/src/preload/ui/settings/settingsInjector.ts
+++ b/src/preload/ui/settings/settingsInjector.ts
@@ -12,12 +12,13 @@ import { STORAGE_KEYS, SELECTORS, FILE_EXTENSIONS } from "../../../constants";
 import { getThemeIcon, getPluginIcon, getAboutIcon } from "../../../utils/icons";
 import { getTransparencyStatus } from "../titleBar";
 import { setupBrowseModsButton } from "../mod/modBrowser";
-import { 
-    setupCheckUpdatesButton, 
-    setupCheckUpdatesOnStartupToggle, 
-    setupDiscordRpcToggle, 
+import {
+    setupCheckUpdatesButton,
+    setupCheckUpdatesOnStartupToggle,
+    setupDiscordRpcToggle,
     setupTransparencyToggle,
-    setupGpuDropdown 
+    setupGpuDropdown,
+    setupExternalPlayerDropdown
 } from "./settingsToggles";
 import { modController } from "../mod/modController";
 import { gpuRendererAPI } from "../../api/gpuRenderer";
@@ -29,11 +30,12 @@ function writeAbout(): void {
         const checkForUpdatesOnStartup = localStorage.getItem(STORAGE_KEYS.CHECK_UPDATES_ON_STARTUP) === "true";
         const discordRpc = localStorage.getItem(STORAGE_KEYS.DISCORD_RPC) === "true";
         const currentAngle = await gpuRendererAPI.getGpuRenderer();
+        const currentExternalPlayer = localStorage.getItem(STORAGE_KEYS.EXTERNAL_PLAYER) ?? 'disabled';
 
         const aboutCategory = document.querySelector(SELECTORS.ABOUT_CATEGORY);
         if (aboutCategory) {
             aboutCategory.innerHTML += getAboutCategoryTemplate(
-                currentVersion, checkForUpdatesOnStartup, discordRpc, isTransparencyEnabled, currentAngle
+                currentVersion, checkForUpdatesOnStartup, discordRpc, isTransparencyEnabled, currentAngle, currentExternalPlayer
             );
         }
     }).catch(err => logger.error("Failed to write about section: " + err));
@@ -63,6 +65,7 @@ export function checkSettings() {
     setupTransparencyToggle();
 
     if(process.platform != "darwin") setupGpuDropdown();
+    setupExternalPlayerDropdown();
 
     Helpers.waitForElm(SELECTORS.THEMES_CATEGORY).then(() => {
         const isCurrentThemeDefault = localStorage.getItem(STORAGE_KEYS.CURRENT_THEME) === "Default";

--- a/src/preload/ui/settings/settingsInjector.ts
+++ b/src/preload/ui/settings/settingsInjector.ts
@@ -18,7 +18,8 @@ import {
     setupDiscordRpcToggle,
     setupTransparencyToggle,
     setupGpuDropdown,
-    setupExternalPlayerDropdown
+    setupExternalPlayerDropdown,
+    setupExternalPlayerPathInputs
 } from "./settingsToggles";
 import { type ExternalPlayer } from "../../../interfaces/ExternalPlayerTypes";
 import { modController } from "../mod/modController";
@@ -32,11 +33,13 @@ function writeAbout(): void {
         const discordRpc = localStorage.getItem(STORAGE_KEYS.DISCORD_RPC) === "true";
         const currentAngle = await gpuRendererAPI.getGpuRenderer();
         const currentExternalPlayer = (localStorage.getItem(STORAGE_KEYS.EXTERNAL_PLAYER) ?? 'disabled') as ExternalPlayer;
+        const vlcCustomPath = localStorage.getItem(STORAGE_KEYS.EXTERNAL_PLAYER_VLC_PATH) ?? '';
+        const mpvCustomPath = localStorage.getItem(STORAGE_KEYS.EXTERNAL_PLAYER_MPV_PATH) ?? '';
 
         const aboutCategory = document.querySelector(SELECTORS.ABOUT_CATEGORY);
         if (aboutCategory) {
             aboutCategory.innerHTML += getAboutCategoryTemplate(
-                currentVersion, checkForUpdatesOnStartup, discordRpc, isTransparencyEnabled, currentAngle, currentExternalPlayer
+                currentVersion, checkForUpdatesOnStartup, discordRpc, isTransparencyEnabled, currentAngle, currentExternalPlayer, vlcCustomPath, mpvCustomPath
             );
         }
     }).catch(err => logger.error("Failed to write about section: " + err));
@@ -67,6 +70,7 @@ export function checkSettings() {
 
     if(process.platform != "darwin") setupGpuDropdown();
     setupExternalPlayerDropdown();
+    setupExternalPlayerPathInputs();
 
     Helpers.waitForElm(SELECTORS.THEMES_CATEGORY).then(() => {
         const isCurrentThemeDefault = localStorage.getItem(STORAGE_KEYS.CURRENT_THEME) === "Default";

--- a/src/preload/ui/settings/settingsInjector.ts
+++ b/src/preload/ui/settings/settingsInjector.ts
@@ -20,6 +20,7 @@ import {
     setupGpuDropdown,
     setupExternalPlayerDropdown
 } from "./settingsToggles";
+import { type ExternalPlayer } from "../../../interfaces/ExternalPlayerTypes";
 import { modController } from "../mod/modController";
 import { gpuRendererAPI } from "../../api/gpuRenderer";
 
@@ -30,7 +31,7 @@ function writeAbout(): void {
         const checkForUpdatesOnStartup = localStorage.getItem(STORAGE_KEYS.CHECK_UPDATES_ON_STARTUP) === "true";
         const discordRpc = localStorage.getItem(STORAGE_KEYS.DISCORD_RPC) === "true";
         const currentAngle = await gpuRendererAPI.getGpuRenderer();
-        const currentExternalPlayer = localStorage.getItem(STORAGE_KEYS.EXTERNAL_PLAYER) ?? 'disabled';
+        const currentExternalPlayer = (localStorage.getItem(STORAGE_KEYS.EXTERNAL_PLAYER) ?? 'disabled') as ExternalPlayer;
 
         const aboutCategory = document.querySelector(SELECTORS.ABOUT_CATEGORY);
         if (aboutCategory) {

--- a/src/preload/ui/settings/settingsToggles.ts
+++ b/src/preload/ui/settings/settingsToggles.ts
@@ -5,6 +5,7 @@ import DiscordPresence from "../../../core/DiscordPresence";
 import { discordTracker } from "../discordTracker";
 import { STORAGE_KEYS, IPC_CHANNELS, CLASSES } from "../../../constants";
 import { gpuRendererAPI } from "../../api/gpuRenderer";
+import { externalPlayerAPI } from "../../api/externalPlayer";
 import { alertAPI } from "../../api/alert";
 
 export function setupCheckUpdatesButton(): void {
@@ -79,4 +80,30 @@ export function setupGpuDropdown() {
             );
         });
     })
+}
+
+export function setupExternalPlayerDropdown() {
+    Helpers.waitForElm('#external-player-dropdown').then(() => {
+        const dropdown = document.getElementById('external-player-dropdown') as HTMLSelectElement;
+        if (!dropdown) return;
+
+        dropdown.addEventListener('change', async (e) => {
+            const selectedValue = (e.target as HTMLSelectElement).value;
+            localStorage.setItem(STORAGE_KEYS.EXTERNAL_PLAYER, selectedValue);
+            logger.info(`External player set to: ${selectedValue}`);
+
+            if (selectedValue !== 'disabled') {
+                const paths = await externalPlayerAPI.getExternalPlayerPaths();
+                const playerPath = selectedValue === 'vlc' ? paths.vlc : paths.mpv;
+                if (!playerPath) {
+                    await alertAPI.showAlert(
+                        "warning",
+                        "Player Not Found",
+                        `${selectedValue.toUpperCase()} was not found on your system. Please install it for this feature to work.`,
+                        ["OK"]
+                    );
+                }
+            }
+        });
+    });
 }

--- a/src/preload/ui/settings/settingsToggles.ts
+++ b/src/preload/ui/settings/settingsToggles.ts
@@ -79,7 +79,7 @@ export function setupGpuDropdown() {
                 ["OK"]
             );
         });
-    })
+    }).catch(() => {});
 }
 
 export function setupExternalPlayerDropdown() {
@@ -94,7 +94,7 @@ export function setupExternalPlayerDropdown() {
 
             if (selectedValue !== 'disabled') {
                 const paths = await externalPlayerAPI.getExternalPlayerPaths();
-                const playerPath = selectedValue === 'vlc' ? paths.vlc : paths.mpv;
+                const playerPath = paths[selectedValue as keyof typeof paths];
                 if (!playerPath) {
                     await alertAPI.showAlert(
                         "warning",
@@ -105,5 +105,5 @@ export function setupExternalPlayerDropdown() {
                 }
             }
         });
-    });
+    }).catch(() => {});
 }

--- a/src/preload/ui/settings/settingsToggles.ts
+++ b/src/preload/ui/settings/settingsToggles.ts
@@ -3,7 +3,7 @@ import Helpers from "../../../utils/Helpers";
 import logger from "../../../utils/logger";
 import DiscordPresence from "../../../core/DiscordPresence";
 import { discordTracker } from "../discordTracker";
-import { STORAGE_KEYS, IPC_CHANNELS, CLASSES } from "../../../constants";
+import { STORAGE_KEYS, IPC_CHANNELS, CLASSES, PLAYER_PATH_STORAGE_KEY } from "../../../constants";
 import { gpuRendererAPI } from "../../api/gpuRenderer";
 import { externalPlayerAPI } from "../../api/externalPlayer";
 import { alertAPI } from "../../api/alert";
@@ -92,17 +92,48 @@ export function setupExternalPlayerDropdown() {
             localStorage.setItem(STORAGE_KEYS.EXTERNAL_PLAYER, selectedValue);
             logger.info(`External player set to: ${selectedValue}`);
 
+            const vlcPathOption = document.getElementById('vlc-path-option');
+            const mpvPathOption = document.getElementById('mpv-path-option');
+            if (vlcPathOption) vlcPathOption.style.display = selectedValue === 'vlc' ? '' : 'none';
+            if (mpvPathOption) mpvPathOption.style.display = selectedValue === 'mpv' ? '' : 'none';
+
             if (selectedValue !== 'disabled') {
-                const paths = await externalPlayerAPI.getExternalPlayerPaths();
-                const playerPath = paths[selectedValue as keyof typeof paths];
-                if (!playerPath) {
-                    await alertAPI.showAlert(
-                        "warning",
-                        "Player Not Found",
-                        `${selectedValue.toUpperCase()} was not found on your system. Please install it for this feature to work.`,
-                        ["OK"]
-                    );
+                const customPath = localStorage.getItem(PLAYER_PATH_STORAGE_KEY[selectedValue]);
+
+                if (!customPath) {
+                    const paths = await externalPlayerAPI.getExternalPlayerPaths();
+                    const playerPath = paths[selectedValue as keyof typeof paths];
+                    if (!playerPath) {
+                        await alertAPI.showAlert(
+                            "warning",
+                            "Player Not Found",
+                            `${selectedValue.toUpperCase()} was not found on your system. You can set a custom path to the player executable below.`,
+                            ["OK"]
+                        );
+                    }
                 }
+            }
+        });
+    }).catch(() => {});
+}
+
+export function setupExternalPlayerPathInputs() {
+    setupPathInput('external-player-vlc-path', STORAGE_KEYS.EXTERNAL_PLAYER_VLC_PATH, 'VLC');
+    setupPathInput('external-player-mpv-path', STORAGE_KEYS.EXTERNAL_PLAYER_MPV_PATH, 'MPV');
+}
+
+function setupPathInput(elementId: string, storageKey: string, playerName: string) {
+    Helpers.waitForElm(`#${elementId}`).then((el) => {
+        const input = el as HTMLInputElement;
+
+        input.addEventListener('change', () => {
+            const value = input.value.trim();
+            if (value) {
+                localStorage.setItem(storageKey, value);
+                logger.info(`Custom ${playerName} path set to: ${value}`);
+            } else {
+                localStorage.removeItem(storageKey);
+                logger.info(`Custom ${playerName} path cleared, using auto-detect`);
             }
         });
     }).catch(() => {});


### PR DESCRIPTION
## Summary

- Adds the ability to redirect streams to an external player (VLC or MPV) instead of the built-in player
- Automatically detects player install paths on Windows, macOS, and Linux, with optional custom path override in settings
- Intercepts player navigation and launches the selected external player with the stream URL, then navigates back

Closes https://github.com/REVENGE977/stremio-enhanced/issues/79
Resolves [TODO: External player option (VLC/MPV)](https://github.com/REVENGE977/stremio-enhanced/blob/main/todo.md)

## How it works

1. User selects VLC/MPV in Settings > Enhanced > External Player dropdown
2. Optionally sets a custom path to the player executable
3. When a stream is played, the interceptor detects the player page, extracts the stream URL, launches the external player via IPC, and navigates back