### PR TITLE
feat: add automatic server.js update checking at startup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -240,6 +240,9 @@ async function chooseStreamingServer() {
 }
 
 async function useServerJS() {
+    // Check for server.js updates from Cargo.toml first
+    await StreamingServer.checkServerJsUpdate();
+
     // First, try to ensure streaming server files are available
     logger.info("Checking for streaming server files...");
     const filesStatus = await StreamingServer.ensureStreamingServerFiles();
@@ -251,7 +254,7 @@ async function useServerJS() {
         // server.js is missing - show instructions to the user in a loop
         logger.info("server.js not found. Showing download instructions to user...");
         const serverDir = StreamingServer.getStreamingServerDir();
-        const downloadUrl = SERVER_JS_URL;
+        const downloadUrl = StreamingServer.latestServerJsUrl || SERVER_JS_URL;
         
         let serverJsFound = false;
         while (!serverJsFound) {
@@ -291,12 +294,18 @@ async function useServerJS() {
                     }
                 } else {
                     // File still not there - warn and show dialog again
-                    await Helpers.showAlert(
+                    const warnResult = await Helpers.showAlert(
                         "warning",
                         "File Not Found",
-                        `server.js was not found in:\n${serverDir}\n\nPlease download the file and place it in the correct location.`,
-                        ["OK"]
+                        `server.js was not found in:\n${serverDir}\n\nPlease download the file and place it in the correct location. Do you want to try again or fallback to Stremio Service?`,
+                        ["Try Again", "Use Stremio Service"]
                     );
+                    
+                    if (warnResult === 1) {
+                        serverJsFound = true; // exit loop
+                        logger.info("User abandoned server.js setup. Falling back to Stremio Service...");
+                        await useStremioService();
+                    }
                 }
             }
         }

--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -14,7 +14,8 @@ class Helpers {
             type: alertType,
             title,
             message,
-            buttons
+            buttons,
+            cancelId: buttons.length > 1 ? 1 : 0
         };
         
         try {

--- a/src/utils/StreamingServer.ts
+++ b/src/utils/StreamingServer.ts
@@ -1,14 +1,17 @@
 import { fork, execSync } from "child_process";
-import { createWriteStream, existsSync, mkdirSync, chmodSync, unlinkSync } from "fs";
+import * as unzipper from "unzipper";
+import { createWriteStream, existsSync, mkdirSync, chmodSync, unlinkSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { getLogger } from "./logger";
 import Properties from "../core/Properties";
 import https from "https";
 import { shell } from "electron";
 import { FFMPEG_URLS, MACOS_FFPROBE_URLS } from "../constants";
+import Helpers from "./Helpers";
 
 class StreamingServer {
     private static logger = getLogger("StreamingServer");
+    public static latestServerJsUrl: string = "";
 
     // Use config directory instead of executable directory for cross-platform compatibility (especially AppImage)
     private static streamingServerDir = join(Properties.enhancedPath, "streamingserver");
@@ -190,15 +193,29 @@ class StreamingServer {
                 unlinkSync(ffprobeArchivePath);
                 return true;
             } else if (process.platform === "win32") {
-                // Handle Windows zip file
-                // Extract the whole archive first
-                execSync(`powershell -Command "Expand-Archive -Path '${archivePath}' -DestinationPath '${this.streamingServerDir}' -Force"`, { encoding: "utf8" });
+                // Handle Windows zip file natively to avoid PowerShell module issues
+                const fs = require('fs');
+                await new Promise<void>((resolve, reject) => {
+                    fs.createReadStream(archivePath)
+                        .pipe(unzipper.Extract({ path: this.streamingServerDir }))
+                        .on('close', resolve)
+                        .on('error', reject);
+                });
                 
-                // Move bin folder contents to the streamingserver directory
-                execSync(`powershell -Command "Move-Item -Path '${this.streamingServerDir}\\ffmpeg-master-latest-win64-gpl\\bin\\*' -Destination '${this.streamingServerDir}' -Force"`, { encoding: "utf8" });
+                const extDir = join(this.streamingServerDir, "ffmpeg-master-latest-win64-gpl");
+                const ffmpegSource = join(extDir, "bin", "ffmpeg.exe");
+                const ffprobeSource = join(extDir, "bin", "ffprobe.exe");
                 
-                // Cleanup: remove extracted directory
-                execSync(`powershell -Command "Remove-Item -Recurse -Force '${this.streamingServerDir}\\ffmpeg-master-latest-win64-gpl'"`, { encoding: "utf8" });
+                if (fs.existsSync(ffmpegSource)) {
+                    fs.renameSync(ffmpegSource, join(this.streamingServerDir, "ffmpeg.exe"));
+                }
+                if (fs.existsSync(ffprobeSource)) {
+                    fs.renameSync(ffprobeSource, join(this.streamingServerDir, "ffprobe.exe"));
+                }
+                
+                if (fs.existsSync(extDir)) {
+                    fs.rmSync(extDir, { recursive: true, force: true });
+                }
 
                 unlinkSync(archivePath);
                 return true;
@@ -278,6 +295,101 @@ class StreamingServer {
         }
 
         return true;
+    }
+
+    private static async fetchText(url: string): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const request = (fetchUrl: string) => {
+                https.get(fetchUrl, { headers: { "User-Agent": "Stremio-Enhanced" } }, (res) => {
+                    if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                        request(new URL(res.headers.location, fetchUrl).toString());
+                        return;
+                    }
+                    if (res.statusCode !== 200) {
+                        reject(new Error(`HTTP ${res.statusCode}`));
+                        return;
+                    }
+                    let data = '';
+                    res.on('data', chunk => data += chunk);
+                    res.on('end', () => resolve(data));
+                }).on("error", err => reject(err));
+            };
+            request(url);
+        });
+    }
+
+    public static async checkServerJsUpdate(): Promise<void> {
+        try {
+            this.logger.info("Checking for server.js updates...");
+            const tomlContent = await this.fetchText("https://raw.githubusercontent.com/Stremio/stremio-service/refs/heads/master/Cargo.toml");
+            const match = tomlContent.match(/\[package\.metadata\.server\][\s\S]*?version\s*=\s*"([^"]+)"/);
+            
+            if (!match) {
+                this.logger.warn("Could not extract server.js version from Cargo.toml");
+                return;
+            }
+            
+            const latestVersion = match[1];
+            const skipVersionPath = join(Properties.enhancedPath, "skip_server_version.txt");
+            const currentVersionPath = join(this.streamingServerDir, "version.txt");
+            
+            if (existsSync(skipVersionPath)) {
+                const skippedVersion = readFileSync(skipVersionPath, "utf8").trim();
+                if (skippedVersion === latestVersion) {
+                    this.logger.info(`User skipped update to ${latestVersion}`);
+                    return;
+                }
+            }
+            
+            let currentVersion = "";
+            if (existsSync(currentVersionPath)) {
+                currentVersion = readFileSync(currentVersionPath, "utf8").trim();
+            }
+            
+            if (currentVersion === latestVersion && existsSync(this.serverScriptPath)) {
+                this.logger.info(`server.js is up to date (${latestVersion})`);
+                return;
+            }
+            
+            const downloadUrl = `https://dl.strem.io/server/${latestVersion}/desktop/server.js`;
+            this.latestServerJsUrl = downloadUrl;
+
+            const isMissing = !existsSync(this.serverScriptPath);
+            const promptMessage = isMissing 
+                ? `The local streaming server (server.js) version ${latestVersion} is required to play videos. Do you want to download and install it now?`
+                : `A new version of the Stremio local server (${latestVersion}) is available. Do you want to update it now?`;
+
+            const response = await Helpers.showAlert(
+                "question",
+                "Server Update",
+                promptMessage,
+                ["Yes", "No", "No and don't ask again"]
+            );
+            
+            if (response === 0) { // Yes
+                if (!isMissing) {
+                    this.logger.info(`Deleting old server.js to trigger update to ${latestVersion}...`);
+                    if (existsSync(this.serverScriptPath)) {
+                        unlinkSync(this.serverScriptPath);
+                    }
+                    if (existsSync(currentVersionPath)) {
+                        unlinkSync(currentVersionPath);
+                    }
+                }
+                // Write the new version to version.txt so that when they manually download it, the version is tracked
+                if (!existsSync(this.streamingServerDir)) {
+                    mkdirSync(this.streamingServerDir, { recursive: true });
+                }
+                writeFileSync(currentVersionPath, latestVersion, "utf8");
+                
+            } else if (response === 2) { // No and don't ask again
+                writeFileSync(skipVersionPath, latestVersion, "utf8");
+                this.logger.info(`Saved skip preference for version ${latestVersion}`);
+            }
+            
+        } catch (error) {
+            this.logger.error("Failed to check for server.js updates: " + error);
+        }
     }
 
     public static start() {

--- a/todo.md
+++ b/todo.md
@@ -41,4 +41,4 @@
 - [x] Give users the choice of what Hardware Acceleration Engine they want Stremio Enhanced to use
 - [x] Create API for plugins to use winston logger
 - [x] Add option to always open streams in either VLC or MPV
-- [ ] Check for server.js updates (if the user is using server.js directly) by checking the latest version of server.js available [in Cargo.toml](https://github.com/Stremio/stremio-service/blob/master/Cargo.toml)
+- [x] Check for server.js updates (if the user is using server.js directly) by checking the latest version of server.js available [in Cargo.toml](https://github.com/Stremio/stremio-service/blob/master/Cargo.toml)


### PR DESCRIPTION
Adds an automatic update checking flow that parses the Cargo.toml of stremio-service on startup. If an update is approved, it deletes the old server.js and gracefully triggers the manual server.js download tutorial with the latest download link, respecting Stremio's request not to automate the download process. Also fixes a bug where FFmpeg download would fail on Windows due to PowerShell execution policies by replacing Expand-Archive with native unzipper extraction.