### PR TITLE
fix: added volume persistency through sessions (#111)

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ import DiscordPresence from "../core/DiscordPresence";
 import { discordTracker } from "./ui/discordTracker";
 import EmbeddedSubtitles from "../utils/EmbeddedSubtitles";
 import AudioTracks from "../utils/AudioTracks";
+import VolumePersistency from "../utils/VolumePersistency";
 import { STORAGE_KEYS, IPC_CHANNELS } from "../constants";
 
 // plugin API bridges
@@ -94,6 +95,7 @@ window.addEventListener("load", () => {
         checkExternalPlayer();
         EmbeddedSubtitles.checkWatching();
         AudioTracks.checkWatching();
+        VolumePersistency.checkWatching();
     });
 
     // Auto update check

--- a/src/utils/VolumePersistency.ts
+++ b/src/utils/VolumePersistency.ts
@@ -1,0 +1,48 @@
+import Helpers from "./Helpers";
+import { getLogger } from "./logger";
+
+const logger = getLogger("VolumePersistency");
+const VOLUME_KEY = "stremio_enhanced_volume_state";
+
+class VolumePersistency {
+    public static async checkWatching() {
+        if (!location.href.includes('#/player')) {
+            return;
+        }
+
+        await Helpers.waitForElm('video');
+        const video = document.querySelector("video") as HTMLVideoElement;
+        if (!video) return;
+
+        if (video.dataset.volumePersisted === "true") {
+            return;
+        }
+        video.dataset.volumePersisted = "true";
+
+        try {
+            const savedState = localStorage.getItem(VOLUME_KEY);
+            if (savedState) {
+                const state = JSON.parse(savedState);
+                if (typeof state.volume === "number" && state.volume >= 0 && state.volume <= 1) {
+                    video.volume = state.volume;
+                }
+                if (typeof state.muted === "boolean") {
+                    video.muted = state.muted;
+                }
+                logger.info(`Restored volume to ${state.volume}, muted: ${state.muted}`);
+            }
+        } catch (e) {
+            logger.error(`Error restoring volume: ${e}`);
+        }
+
+        video.addEventListener("volumechange", () => {
+            const state = {
+                volume: video.volume,
+                muted: video.muted
+            };
+            localStorage.setItem(VOLUME_KEY, JSON.stringify(state));
+        });
+    }
+}
+
+export default VolumePersistency;

--- a/todo.md
+++ b/todo.md
@@ -42,4 +42,4 @@
 - [x] Create API for plugins to use winston logger
 - [x] Add option to always open streams in either VLC or MPV
 - [x] Check for server.js updates (if the user is using server.js directly) by checking the latest version of server.js available [in Cargo.toml](https://github.com/Stremio/stremio-service/blob/master/Cargo.toml)
-- [ ] Memorize current volume for future streams
+- [x] Memorize current volume for future streams


### PR DESCRIPTION
## Description
This PR fixes a bug where the player volume is always set to 100% on startup, failing to remember the user's previous volume settings across sessions.
Fixes #111
Present in [todo.md](https://github.com/REVENGE977/stremio-enhanced/blob/main/todo.md)

Since Stremio-Enhanced utilizes a custom Electron wrapper around Stremio Web's UI, the default behavior of the HTML5 `<video>` tag resets the volume to 100% on every player load without an overarching shell to handle persistency.

## Key Changes
- **New Utility (`VolumePersistency.ts`)**: Injects a one-time volume restore when the user opens the player (`#/player`). It reads the `stremio_enhanced_volume_state` from `localStorage` and applies it natively to the video element.
- **State Tracking**: Attaches a `volumechange` event listener directly to the `<video>` element, immediately saving the volume and mute state to `localStorage` whenever the user adjusts the volume slider or mutes the player in the Stremio UI.
- **Preload Integration**: Hooked `VolumePersistency.checkWatching()` into the existing `hashchange` interceptor in `src/preload/index.ts`.

## Testing
- Verified volume persists after changing it, closing the player, and opening a new video.
- Verified mute state is preserved.
- Typescript compilation passes cleanly (`npm run dist`).
