### PR TITLE
feat: added SSA and ASS subtitle codec support (#107)

### DIFF
--- a/src/utils/EmbeddedSubtitles.ts
+++ b/src/utils/EmbeddedSubtitles.ts
@@ -67,6 +67,7 @@ class EmbeddedSubtitles {
         queryParams.append("maxAudioChannels", "2");
         ['h264', 'h265', 'hevc', 'vp9'].forEach(c => queryParams.append('videoCodecs', c));
         ['aac', 'mp3', 'opus'].forEach(c => queryParams.append('audioCodecs', c));
+        ['vtt', 'srt', 'ass', 'ssa'].forEach(c => queryParams.append('subtitleCodecs', c));
 
         const masterUrl = streamURL.includes('.m3u8') 
             ? streamURL 
@@ -231,7 +232,11 @@ class EmbeddedSubtitles {
             
             const startTime = this.parseVttTime(startStr);
             const endTime = this.parseVttTime(endStr);
-            const text = lines.slice(timeLineIndex + 1).join('\n');
+            let text = lines.slice(timeLineIndex + 1).join('\n');
+            
+            // Strip ASS/SSA override tags (e.g., {\an8}, {\c&H0000FF&})
+            // which ffmpeg might leave in when converting ASS to VTT
+            text = text.replace(/\{.*?\}/g, '');
 
             try {
                 track.addCue(new VTTCue(startTime, endTime, text));


### PR DESCRIPTION
## Description
This PR resolves the lack of embedded SSA/ASS subtitles by explicitly instructing the Stremio Streaming Server to extract and convert them into the HLS playlist.

Fixes #107 

## Key Changes
- **Updated API Query (`EmbeddedSubtitles.ts`)**: Appended `subtitleCodecs=vtt,srt,ass,ssa` to the HLS playlist request URL. This prompts Stremio's internal `enginefs` to extract `.ass` and `.ssa` subtitle tracks from MKV files and serve them as VTT segmented playlists, allowing our embedded subtitle fetcher to see them.
- **SSA Tag Stripping (`injectVttCues`)**: When `stremio-server` extracts ASS to VTT, it often leaves complex override tags (e.g., `{\an8}`, `{\c&H0000FF&}`) in the raw text. A regex stripper was added to our VTT parser to clean these tags before injecting them into the DOM via `VTTCue`, ensuring the text looks clean and legible in the HTML5 player.

## Testing
- Tested MKV files with embedded SSA subtitles; tracks now correctly appear in the subtitle menu.
- Verified that override tags are cleanly stripped, displaying normal text instead of raw syntax.
- Typescript compilation passes cleanly (`npm run dist`).
