### PR TITLE
perf: optimized subtitle loading logic to make it faster (#103)

### DIFF
--- a/src/utils/EmbeddedSubtitles.ts
+++ b/src/utils/EmbeddedSubtitles.ts
@@ -87,19 +87,18 @@ class EmbeddedSubtitles {
         const dummyBlobUrl = URL.createObjectURL(new Blob(["WEBVTT\n\n"], { type: "text/vtt" }));
         
         const fragment = document.createDocumentFragment();
-        let isFirstTrack = true;
         let isFullyInitialized = false;
 
-        for (const subLine of subLines) {
+        const subData = await Promise.all(subLines.map(async (subLine, index) => {
             const uriMatch = subLine.match(/URI="([^"]+)"/);
             const langMatch = subLine.match(/LANGUAGE="([^"]+)"/);
             const nameMatch = subLine.match(/NAME="([^"]+)"/);
             
-            if (!uriMatch) continue;
+            if (!uriMatch) return null;
 
             const subPlaylistUrl = new URL(uriMatch[1], masterUrl).toString();
-            const subPlaylistRes = await fetch(subPlaylistUrl);
-            if (!subPlaylistRes.ok) continue;
+            const subPlaylistRes = await fetch(subPlaylistUrl).catch(() => null);
+            if (!subPlaylistRes || !subPlaylistRes.ok) return null;
 
             const lines = (await subPlaylistRes.text()).split('\n');
             const segments: { url: string, start: number, end: number, fetched: boolean }[] = [];
@@ -119,16 +118,20 @@ class EmbeddedSubtitles {
                     currentTime += duration;
                 }
             }
+            return { index, langMatch, nameMatch, segments };
+        }));
+
+        for (const data of subData) {
+            if (!data) continue;
 
             const trackEl = document.createElement("track");
             trackEl.kind = "subtitles";
-            trackEl.label = nameMatch ? nameMatch[1] : "Embedded";
-            trackEl.srclang = langMatch ? langMatch[1] : "en";
+            trackEl.label = data.nameMatch ? data.nameMatch[1] : "Embedded";
+            trackEl.srclang = data.langMatch ? data.langMatch[1] : "en";
             trackEl.src = dummyBlobUrl; 
             
-            if (isFirstTrack) {
+            if (tracksAdded === 0) {
                 trackEl.default = true; // Wakes up Stremio UI to add the subs to the subtitles menu
-                isFirstTrack = false;
             }
 
             fragment.appendChild(trackEl);
@@ -146,7 +149,7 @@ class EmbeddedSubtitles {
                     if (isFetching) return; 
 
                     const lookaheadTime = video.currentTime + 10; 
-                    const neededSegments = segments.filter(seg => 
+                    const neededSegments = data.segments.filter(seg => 
                         !seg.fetched && 
                         seg.start <= lookaheadTime && 
                         seg.end >= video.currentTime - 2
@@ -155,8 +158,8 @@ class EmbeddedSubtitles {
                     if (neededSegments.length > 0) {
                         isFetching = true;
 
-                        for (const seg of neededSegments) {
-                            if (seg.start > video.currentTime + 20 || seg.end < video.currentTime - 5) continue;
+                        const segmentPromises = neededSegments.map(async (seg) => {
+                            if (seg.start > video.currentTime + 20 || seg.end < video.currentTime - 5) return;
 
                             seg.fetched = true; 
                             
@@ -168,9 +171,10 @@ class EmbeddedSubtitles {
                             } catch (err) {
                                 logger.error(`Segment at ${seg.start} failed ${err}`);
                                 setTimeout(() => { seg.fetched = false; }, 2000);
-                                break; 
                             }
-                        }
+                        });
+
+                        await Promise.all(segmentPromises);
                         isFetching = false;
                     }
                 });


### PR DESCRIPTION
## Description
This PR drastically improves the load times of embedded subtitles and the responsiveness when switching subtitle languages during playback.

Fixes #103 

Previously, embedded subtitle playlists and VTT segments were fetched sequentially within a `for...of` loop. This caused a severe bottleneck, leading to wait times of up to a minute on files with numerous embedded subtitle tracks. 

## Key Changes
- **Concurrent Playlist Initialization**: Refactored `initializeJITSubtitles` to fetch all HLS subtitle playlists concurrently using `Promise.all`, while strictly maintaining their original index order.
- **Concurrent Segment Fetching**: The `timeupdate` listener now fetches all necessary lookahead subtitle segments concurrently rather than sequentially.

## Testing
- Verified that files with 10+ embedded subtitles now populate the subtitle menu almost instantly.
- Verified that switching languages mid-playback retrieves the new subtitle cues without delay.
