### PR TITLE
feat: added persistency to window state via localStorage (#60)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { BrowserWindow, shell } from "electron";
 import StreamingServer from "./utils/StreamingServer";
 import Helpers from "./utils/Helpers";
 import StremioService from "./utils/StremioService";
+import { WindowStateManager } from "./utils/WindowState";
 import { setupPluginSettingsAPI } from "./controllers/api/SettingsApiController";
 import { setupPluginAlertAPI } from "./controllers/api/AlertApiController";
 import { setupWindowControls } from "./controllers/windowController";
@@ -58,6 +59,9 @@ if (!gotLock) {
 }
 
 async function createWindow() {
+    const windowState = new WindowStateManager();
+    const bounds = windowState.getBounds();
+
     mainWindow = new BrowserWindow({
         webPreferences: {
             preload: join(__dirname, "//preload/index.js"),
@@ -74,8 +78,10 @@ async function createWindow() {
             spellcheck: false,
             backgroundThrottling: false
         },
-        width: 1500,
-        height: 850,
+        x: bounds.x,
+        y: bounds.y,
+        width: bounds.width || 1500,
+        height: bounds.height || 850,
         resizable: true,
         maximizable: true,
         fullscreenable: true,
@@ -88,6 +94,7 @@ async function createWindow() {
         backgroundColor: "#00000000",
     });
     
+    windowState.manage(mainWindow);
     mainWindow.setMenu(null);
     mainWindow.loadURL(URLS.STREMIO_WEB);
         

--- a/src/utils/WindowState.ts
+++ b/src/utils/WindowState.ts
@@ -1,0 +1,105 @@
+import { app, BrowserWindow } from "electron";
+import { join } from "path";
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { getLogger } from "./logger";
+
+const logger = getLogger("WindowState");
+
+export interface WindowState {
+    x?: number;
+    y?: number;
+    width: number;
+    height: number;
+    isMaximized: boolean;
+    isFullScreen: boolean;
+}
+
+export class WindowStateManager {
+    private state: WindowState;
+    private stateFilePath: string;
+
+    constructor() {
+        this.stateFilePath = join(app.getPath("userData"), "window-state.json");
+        this.state = this.loadState();
+    }
+
+    private loadState(): WindowState {
+        const defaultState: WindowState = {
+            width: 1500,
+            height: 850,
+            isMaximized: false,
+            isFullScreen: false,
+        };
+
+        try {
+            if (existsSync(this.stateFilePath)) {
+                const data = readFileSync(this.stateFilePath, "utf8");
+                const savedState = JSON.parse(data);
+                return { ...defaultState, ...savedState };
+            }
+        } catch (error) {
+            logger.error(`Failed to load window state: ${error}`);
+        }
+        return defaultState;
+    }
+
+    private saveState() {
+        try {
+            writeFileSync(this.stateFilePath, JSON.stringify(this.state));
+        } catch (error) {
+            logger.error(`Failed to save window state: ${error}`);
+        }
+    }
+
+    public getBounds(): Partial<WindowState> {
+        return {
+            x: this.state.x,
+            y: this.state.y,
+            width: this.state.width,
+            height: this.state.height
+        };
+    }
+
+    public manage(window: BrowserWindow) {
+        if (this.state.isMaximized) {
+            window.maximize();
+        }
+        if (this.state.isFullScreen) {
+            window.setFullScreen(true);
+        }
+
+        const updateState = () => {
+            try {
+                if (!window.isMaximized() && !window.isFullScreen()) {
+                    const bounds = window.getBounds();
+                    this.state.x = bounds.x;
+                    this.state.y = bounds.y;
+                    this.state.width = bounds.width;
+                    this.state.height = bounds.height;
+                }
+                this.state.isMaximized = window.isMaximized();
+                this.state.isFullScreen = window.isFullScreen();
+            } catch (e) {
+                // Ignore if window is already destroyed
+            }
+        };
+
+        let saveTimeout: NodeJS.Timeout | null = null;
+        const triggerSave = () => {
+            updateState();
+            if (saveTimeout) clearTimeout(saveTimeout);
+            saveTimeout = setTimeout(() => this.saveState(), 500);
+        };
+
+        window.on("resize", triggerSave);
+        window.on("move", triggerSave);
+        window.on("maximize", triggerSave);
+        window.on("unmaximize", triggerSave);
+        window.on("enter-full-screen", triggerSave);
+        window.on("leave-full-screen", triggerSave);
+        window.on("close", () => {
+            updateState();
+            this.saveState();
+        });
+    }
+}


### PR DESCRIPTION
## Description
This PR implements window state persistency across sessions. 

Fixes #60  (it was'nt a MacOS only issue)

## Key Changes
- **New WindowStateManager (`src/utils/WindowState.ts`)**: Created a lightweight class to track the window's `x`, `y`, `width`, `height`, `isMaximized`, and `isFullScreen` properties. It listens to Electron's native window events (`resize`, `move`, `maximize`, `enter-full-screen`, etc.) with a 500ms debounce and saves the state to `window-state.json` in the user's data directory.
- **Main Process Integration**: Updated `createWindow` in `src/main.ts` to retrieve these bounds prior to creating the `BrowserWindow`. The window now successfully resumes its previous size, position, and fullscreen/maximized state on launch.

## Testing
- Tested on Windows/macOS/Linux.
- Verified that switching to full screen, quitting the app, and reopening restores the app directly to full screen.
- Verified that standard window dimensions and positions are correctly remembered across multiple monitors.
