### PR TITLE
feat: now stremio enhanced sends subtitle tracks to external players (#113)

### DIFF
--- a/src/controllers/externalPlayerController.ts
+++ b/src/controllers/externalPlayerController.ts
@@ -118,7 +118,7 @@ function startPolling(player: ExternalPlayer, child: ReturnType<typeof execFile>
 
 export const externalPlayerController = {
     initIPC: () => {
-        ipcMain.handle(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, (_, player: string, streamUrl: string, customPath?: string) => {
+        ipcMain.handle(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, (_, player: string, streamUrl: string, customPath?: string, subtitles?: { url: string; lang: string }[]) => {
             if (!VALID_EXTERNAL_PLAYERS.includes(player as ExternalPlayer) || player === 'disabled') {
                 logger.error(`Invalid external player: ${player}`);
                 return { success: false, error: `Invalid player: ${player}` };
@@ -142,6 +142,12 @@ export const externalPlayerController = {
             const args = player === 'mpv'
                 ? [streamUrl, `--input-ipc-server=${MPV_SOCKET}`]
                 : [streamUrl, '--extraintf=http', `--http-password=${VLC_HTTP_PASSWORD}`, `--http-port=${VLC_HTTP_PORT}`];
+
+            if (subtitles && subtitles.length > 0) {
+                for (const sub of subtitles) {
+                    args.push(`--sub-file=${sub.url}`);
+                }
+            }
 
             logger.info(`Launching ${player} at ${playerPath} with URL: ${streamUrl}`);
 

--- a/src/interfaces/PlayerState.ts
+++ b/src/interfaces/PlayerState.ts
@@ -4,7 +4,8 @@ import MetaDetails from "./MetaDetails";
 interface PlayerState {
     seriesInfoDetails: SeriesInfo | null;
     metaDetails: MetaDetails;
-    stream?: { content: { url: string } };
+    stream?: { content: { url: string; subtitles?: { url: string; lang: string }[] } };
+    subtitles?: { url: string; lang: string }[];
 }
 
 export default PlayerState;

--- a/src/preload/api/externalPlayer.ts
+++ b/src/preload/api/externalPlayer.ts
@@ -3,8 +3,8 @@ import { IPC_CHANNELS } from '../../constants';
 import { type ExternalPlayer } from '../../interfaces/ExternalPlayerTypes';
 
 export const externalPlayerAPI = {
-    launchExternalPlayer: (player: ExternalPlayer, streamUrl: string, customPath?: string): Promise<{ success: boolean; error?: string }> => {
-        return ipcRenderer.invoke(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, player, streamUrl, customPath);
+    launchExternalPlayer: (player: ExternalPlayer, streamUrl: string, customPath?: string, subtitles?: { url: string; lang: string }[]): Promise<{ success: boolean; error?: string }> => {
+        return ipcRenderer.invoke(IPC_CHANNELS.LAUNCH_EXTERNAL_PLAYER, player, streamUrl, customPath, subtitles);
     },
     getExternalPlayerPaths: (): Promise<{ vlc: string | null; mpv: string | null }> => {
         return ipcRenderer.invoke(IPC_CHANNELS.GET_EXTERNAL_PLAYER_PATHS);

--- a/src/preload/ui/externalPlayerInterceptor.ts
+++ b/src/preload/ui/externalPlayerInterceptor.ts
@@ -38,6 +38,10 @@ async function launchExternal(player: ExternalPlayer): Promise<void> {
         }
 
         const streamUrl = playerState.stream.content.url;
+        const streamSubs = playerState.stream.content.subtitles || [];
+        const externalSubs = playerState.subtitles || [];
+        const allSubs = [...streamSubs, ...externalSubs];
+
         logger.info(`Launching ${player} with stream URL: ${streamUrl}`);
        
         discordTracker.lastPlayerState = playerState;  
@@ -47,7 +51,7 @@ async function launchExternal(player: ExternalPlayer): Promise<void> {
         history.back();
         const customPath = localStorage.getItem(PLAYER_PATH_STORAGE_KEY[player]);
         
-        const result = await externalPlayerAPI.launchExternalPlayer(player, streamUrl, customPath || undefined);
+        const result = await externalPlayerAPI.launchExternalPlayer(player, streamUrl, customPath || undefined, allSubs);
         
         if (result.success) {
             Helpers.createToast("extPlayerLaunch", "External Player", `Opening stream in ${player.toUpperCase()}...`, "success");

--- a/src/utils/PlaybackState.ts
+++ b/src/utils/PlaybackState.ts
@@ -35,14 +35,16 @@ class PlaybackState {
                 const playerState = await Helpers._eval('core.getState("player")') as {
                     seriesInfo?: SeriesInfo;
                     metaItem?: { content?: MetaDetails }
-                    stream?: { content: { url: string } }
+                    stream?: { content: { url: string; subtitles?: { url: string; lang: string }[] } };
+                    subtitles?: { url: string; lang: string }[];
                 };
                 
                 if(playerState?.metaItem?.content) {
                     return {
                         seriesInfoDetails: playerState?.seriesInfo ?? null,
                         metaDetails: playerState!.metaItem!.content,
-                        stream: playerState?.stream
+                        stream: playerState?.stream,
+                        subtitles: playerState?.subtitles
                     };
                 }
 


### PR DESCRIPTION
## Description
This PR adds support for passing all subtitle tracks (both stream-embedded and addon-downloaded, like OpenSubtitles) directly to the external player (MPV/VLC).

Fixes #113 

## Key Changes
- **State Extraction**: Modified `PlaybackState.ts` and `PlayerState.ts` to extract the global `subtitles` array from Stremio Core's internal state (which houses addon-provided subtitles), alongside the stream's native `content.subtitles`.
- **Interceptor Update**: The `externalPlayerInterceptor` now concatenates all available subtitles and passes them via IPC when launching the player.
- **Player Arguments**: Updated `externalPlayerController.ts` to dynamically append `--sub-file=<url>` arguments to the child process spawning MPV and VLC. Both players natively support HTTP endpoints for subtitles, allowing them to fetch Stremio's addon subtitles perfectly.

## Testing
- Verified that launching an external player with OpenSubtitles enabled successfully loads the subtitle tracks into MPV's subtitle menu.
- Verified no regression for streams without external subtitles.
