### PR TITLE
feat: add toggle all plugins button (#104)

### DIFF
--- a/src/preload/ui/mod/modController.ts
+++ b/src/preload/ui/mod/modController.ts
@@ -196,6 +196,37 @@ export const modController = {
                 ModManager.openFolder(Properties.pluginsPath));
         });
     },
+
+    bindToggleAllPluginsButton: (): void => {
+        helpers.waitForElm("#toggleallpluginsBtn").then(() => {
+            document.getElementById("toggleallpluginsBtn")?.addEventListener("click", () => {
+                const pluginCheckboxes = document.getElementsByClassName("plugin") as HTMLCollectionOf<HTMLElement>;
+                const enabledPlugins = JSON.parse(localStorage.getItem(STORAGE_KEYS.ENABLED_PLUGINS) || "[]");
+                
+                const shouldEnableAll = enabledPlugins.length === 0;
+                
+                for (let i = 0; i < pluginCheckboxes.length; i++) {
+                    const pluginName = pluginCheckboxes[i].getAttribute('name');
+                    if (!pluginName) continue;
+                    
+                    const isChecked = pluginCheckboxes[i].classList.contains(CLASSES.CHECKED);
+                    
+                    if (shouldEnableAll && !isChecked) {
+                        pluginCheckboxes[i].classList.add(CLASSES.CHECKED);
+                        modController.loadPlugin(pluginName);
+                    } else if (!shouldEnableAll && isChecked) {
+                        pluginCheckboxes[i].classList.remove(CLASSES.CHECKED);
+                        modController.unloadPlugin(pluginName);
+                        settingsAPI.clearRegisteredSettings(pluginName.split(FILE_EXTENSIONS.PLUGIN)[0]);
+                    }
+                }
+                
+                if (!shouldEnableAll) {
+                    modController._showReloadWarning();
+                }
+            });
+        });
+    },
         
     scrollListener: (): void => {
         helpers.waitForElm('div > div[title="Enhanced"]').then(() => {

--- a/src/preload/ui/settings/settingsInjector.ts
+++ b/src/preload/ui/settings/settingsInjector.ts
@@ -60,6 +60,7 @@ export function checkSettings() {
     
     settingsBuilder.addButton("Open Themes Folder", "openthemesfolderBtn", SELECTORS.THEMES_CATEGORY);
     settingsBuilder.addButton("Open Plugins Folder", "openpluginsfolderBtn", SELECTORS.PLUGINS_CATEGORY);
+    settingsBuilder.addButton("Toggle All Plugins", "toggleallpluginsBtn", SELECTORS.PLUGINS_CATEGORY);
     
     writeAbout();
     setupBrowseModsButton();
@@ -95,4 +96,5 @@ export function checkSettings() {
     modController.scrollListener();
     modController.bindPluginOptionsListeners();
     modController.bindFolderButtons();
+    modController.bindToggleAllPluginsButton();
 }


### PR DESCRIPTION
## Description
Added a new "Toggle All Plugins" button in the plugins settings category. This allows users to quickly enable or disable all plugins with a single click, saving time when managing multiple addons.

**How it works:**
    - If no plugins are currently enabled, clicking the button will enable all of them.
    - If one or more plugins are already active, clicking it will disable all of them and prompt the
  standard reload warning to apply changes.

Fixes #104